### PR TITLE
Remove emails from all classes.

### DIFF
--- a/geex-core/src/main/java/nl/tudelft/context/App.java
+++ b/geex-core/src/main/java/nl/tudelft/context/App.java
@@ -9,7 +9,7 @@ import nl.tudelft.context.controller.MainController;
 /**
  * Entry point of the App.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 23-4-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/breadcrumb/Breadcrumb.java
+++ b/geex-core/src/main/java/nl/tudelft/context/breadcrumb/Breadcrumb.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 14-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/AbstractController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/AbstractController.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 /**
  * @param <T> fxml root type
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 26-4-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/AbstractGraphController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/AbstractGraphController.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 2-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/AbstractNewickController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/AbstractNewickController.java
@@ -12,7 +12,7 @@ import java.net.URL;
 import java.util.ResourceBundle;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 5-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/BaseController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/BaseController.java
@@ -13,7 +13,7 @@ import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 8-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/GraphController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/GraphController.java
@@ -16,7 +16,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 7-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 25-4-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/MenuController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/MenuController.java
@@ -10,7 +10,7 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyCombination;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 8-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/NewickController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/NewickController.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 8-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/SelectNewickController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/SelectNewickController.java
@@ -12,7 +12,7 @@ import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 5-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/SubGraphController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/SubGraphController.java
@@ -8,7 +8,7 @@ import java.net.URL;
 import java.util.ResourceBundle;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 2-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/ViewController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/ViewController.java
@@ -6,7 +6,7 @@ import javafx.scene.Parent;
 
 /**
  * @param <T> fxml root type
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 14-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
@@ -22,7 +22,7 @@ import java.util.ResourceBundle;
 import static java.util.stream.Collectors.toList;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 18-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/controller/overlay/OverlayController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/overlay/OverlayController.java
@@ -9,7 +9,7 @@ import java.net.URL;
 import java.util.ResourceBundle;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 21-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/DrawableEdge.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/DrawableEdge.java
@@ -8,7 +8,7 @@ import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DefaultWeightedEdge;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/DrawableNewickNode.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/DrawableNewickNode.java
@@ -3,7 +3,7 @@ package nl.tudelft.context.drawable;
 import nl.tudelft.context.model.newick.Node;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 8-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/DrawablePosition.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/DrawablePosition.java
@@ -4,7 +4,7 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 31-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/NewickLabel.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/NewickLabel.java
@@ -5,7 +5,7 @@ import nl.tudelft.context.model.newick.Node;
 import nl.tudelft.context.model.newick.selection.Selection;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 18-05-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/AbstractDrawableNode.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/AbstractDrawableNode.java
@@ -6,7 +6,7 @@ import nl.tudelft.context.drawable.DrawablePosition;
 import nl.tudelft.context.model.graph.DefaultNode;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/AbstractLabel.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/AbstractLabel.java
@@ -3,7 +3,7 @@ package nl.tudelft.context.drawable.graph;
 import javafx.scene.layout.VBox;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableGraph.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableGraph.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 31-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableGraphNode.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableGraphNode.java
@@ -5,7 +5,7 @@ import nl.tudelft.context.controller.MainController;
 import nl.tudelft.context.model.graph.GraphNode;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 7-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableGraphNodeLabel.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableGraphNodeLabel.java
@@ -9,7 +9,7 @@ import nl.tudelft.context.model.graph.GraphNode;
 /**
  * The Javafx part of DrawableGraphNode.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableNode.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableNode.java
@@ -5,7 +5,7 @@ import nl.tudelft.context.controller.MainController;
 import nl.tudelft.context.model.graph.Node;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 7-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableNodeFactory.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableNodeFactory.java
@@ -7,7 +7,7 @@ import nl.tudelft.context.model.graph.Node;
 /**
  * Create a Drawable from a Node.
  *
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 7-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableNodeLabel.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/DrawableNodeLabel.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 /**
  * The Javafx part of DrawableNode.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 13-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/graph/package-info.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/graph/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Everything drawable used in the Graph view.
  *
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 7-6-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/drawable/package-info.java
+++ b/geex-core/src/main/java/nl/tudelft/context/drawable/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Everything in this package is drawable in JavaFx.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-5-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/effects/Zoom.java
+++ b/geex-core/src/main/java/nl/tudelft/context/effects/Zoom.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 01-06-2015
  */

--- a/geex-core/src/main/java/nl/tudelft/context/effects/package-info.java
+++ b/geex-core/src/main/java/nl/tudelft/context/effects/package-info.java
@@ -1,7 +1,7 @@
 /**
  * This package is contains visual effects.
  *
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 03-06-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/controller/BaseControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/BaseControllerTest.java
@@ -15,7 +15,7 @@ import java.util.HashSet;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 8-5-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/controller/GraphControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/GraphControllerTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 26-4-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/controller/MainControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/MainControllerTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 26-4-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
@@ -17,8 +17,8 @@ import static junit.framework.TestCase.*;
 import static org.mockito.Mockito.*;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author René Vennik
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 26-4-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/controller/OverlayControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/OverlayControllerTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 22-5-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/drawable/NewickLabelTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/drawable/NewickLabelTest.java
@@ -11,7 +11,7 @@ import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 18-05-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/drawable/graph/DrawableNodeFactoryTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/drawable/graph/DrawableNodeFactoryTest.java
@@ -10,7 +10,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.mockito.Mockito.mock;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 7-6-2015
  */

--- a/geex-core/src/test/java/nl/tudelft/context/effects/ZoomTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/effects/ZoomTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import static org.mockito.Mockito.*;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 03-06-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
@@ -9,7 +9,7 @@ import java.io.UnsupportedEncodingException;
 
 /**
  * @param <T> The filetype this parser should parse to.
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 24-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/BaseCounter.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/BaseCounter.java
@@ -7,7 +7,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 /**
- * @author Jasper Nieuwdorp <jaspernieuwdorp@hotmail.com>
+ * @author Jasper Nieuwdorp
  * @version 1.2
  * @since 06-05-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/DefaultGraph.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/DefaultGraph.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 /**
  * @param <T> Type of the nodes
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 31-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/DefaultNode.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/DefaultNode.java
@@ -3,7 +3,7 @@ package nl.tudelft.context.model.graph;
 import java.util.Set;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-6-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/Graph.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/Graph.java
@@ -3,7 +3,7 @@ package nl.tudelft.context.model.graph;
 /**
  * Graph.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 23-4-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphMap.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphMap.java
@@ -11,7 +11,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 20-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphNode.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphNode.java
@@ -6,7 +6,7 @@ import java.util.Queue;
 import java.util.Set;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-6-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphParser.java
@@ -10,7 +10,7 @@ import java.util.Scanner;
 /**
  * GraphParser.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 23-4-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/Node.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/Node.java
@@ -3,7 +3,7 @@ package nl.tudelft.context.model.graph;
 import java.util.Set;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.1
  * @since 23-4-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/NodeParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/NodeParser.java
@@ -6,7 +6,7 @@ import java.util.Scanner;
 import java.util.Set;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 24-4-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/SinglePointGraph.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/SinglePointGraph.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-6-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/StackGraph.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/StackGraph.java
@@ -3,7 +3,7 @@ package nl.tudelft.context.model.graph;
 import java.util.Set;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 1-6-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/package-info.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Package containing all files related to creating a Graph.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.1
  * @since 23-4-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/Newick.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/Newick.java
@@ -4,7 +4,7 @@ import org.jgrapht.graph.DefaultDirectedGraph;
 import org.jgrapht.graph.DefaultEdge;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 3-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/NewickParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/NewickParser.java
@@ -8,7 +8,7 @@ import nl.tudelft.context.model.Parser;
 import java.io.BufferedReader;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 3-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/Node.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/Node.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 3-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/NodeParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/NodeParser.java
@@ -3,7 +3,7 @@ package nl.tudelft.context.model.newick;
 import net.sourceforge.olduvai.treejuxtaposer.drawer.TreeNode;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 3-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/package-info.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Package containing all classes related to creating a Newick tree.
  *
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 3-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/All.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/All.java
@@ -1,7 +1,7 @@
 package nl.tudelft.context.model.newick.selection;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 22-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/None.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/None.java
@@ -1,7 +1,7 @@
 package nl.tudelft.context.model.newick.selection;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 22-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/Partial.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/Partial.java
@@ -1,7 +1,7 @@
 package nl.tudelft.context.model.newick.selection;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 22-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/Selection.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/Selection.java
@@ -1,7 +1,7 @@
 package nl.tudelft.context.model.newick.selection;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 22-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/package-info.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/selection/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Package containing selection classes for double dispatch.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 22-5-2015
  */

--- a/geex-models/src/main/java/nl/tudelft/context/model/package-info.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/package-info.java
@@ -1,7 +1,7 @@
 /**
  * This package is the root for all model classes.
  *
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 24-5-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/ParserTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/ParserTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 24-5-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/graph/GraphNodeTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/graph/GraphNodeTest.java
@@ -17,7 +17,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 3-6-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/graph/GraphTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/graph/GraphTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit test for Graph.
  *
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.1
  * @since 23-4-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/graph/NodeTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/graph/NodeTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 24-4-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/newick/NewickFactoryTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/newick/NewickFactoryTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 13-05-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/newick/NewickTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/newick/NewickTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 06-05-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/newick/NodeFactoryTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/newick/NodeFactoryTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 13-05-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/newick/NodeTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/newick/NodeTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 06-05-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/newick/selection/AllTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/newick/selection/AllTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 30-05-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/newick/selection/NoneTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/newick/selection/NoneTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 30-05-2015
  */

--- a/geex-models/src/test/java/nl/tudelft/context/model/newick/selection/PartialTest.java
+++ b/geex-models/src/test/java/nl/tudelft/context/model/newick/selection/PartialTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 30-05-2015
  */

--- a/geex-services/src/main/java/nl/tudelft/context/service/LoadService.java
+++ b/geex-services/src/main/java/nl/tudelft/context/service/LoadService.java
@@ -7,7 +7,7 @@ import nl.tudelft.context.model.Parser;
 import java.io.File;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 24-5-2015
  * @param <T> The type of class to Load.

--- a/geex-services/src/test/java/nl/tudelft/context/service/LoadGraphServiceTest.java
+++ b/geex-services/src/test/java/nl/tudelft/context/service/LoadGraphServiceTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * @author René Vennik <renevennik@gmail.com>
+ * @author René Vennik
  * @version 1.0
  * @since 26-4-2015
  */

--- a/geex-services/src/test/java/nl/tudelft/context/service/LoadNewickServiceTest.java
+++ b/geex-services/src/test/java/nl/tudelft/context/service/LoadNewickServiceTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertNotNull;
 
 /**
- * @author Jasper Boot <mrjasperboot@gmail.com>
+ * @author Jasper Boot
  * @version 1.0
  * @since 1-5-2015
  */

--- a/geex-workspace/src/main/java/nl/tudelft/context/workspace/Database.java
+++ b/geex-workspace/src/main/java/nl/tudelft/context/workspace/Database.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 1-6-2015
  */

--- a/geex-workspace/src/main/java/nl/tudelft/context/workspace/Workspace.java
+++ b/geex-workspace/src/main/java/nl/tudelft/context/workspace/Workspace.java
@@ -17,7 +17,7 @@ import java.io.FileNotFoundException;
 import java.util.Arrays;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 8-5-2015
  */

--- a/geex-workspace/src/main/java/nl/tudelft/context/workspace/package-info.java
+++ b/geex-workspace/src/main/java/nl/tudelft/context/workspace/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Package for the workspace.
  *
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 12-5-2015
  */

--- a/geex-workspace/src/test/java/nl/tudelft/context/workspace/DatabaseTest.java
+++ b/geex-workspace/src/test/java/nl/tudelft/context/workspace/DatabaseTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.0
  * @since 5-6-2015
  */

--- a/geex-workspace/src/test/java/nl/tudelft/context/workspace/WorkspaceTest.java
+++ b/geex-workspace/src/test/java/nl/tudelft/context/workspace/WorkspaceTest.java
@@ -8,7 +8,7 @@ import java.io.FileNotFoundException;
 import static junit.framework.TestCase.assertEquals;
 
 /**
- * @author Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>
+ * @author Gerben Oolbekkink
  * @version 1.1
  * @since 9-5-2015
  */


### PR DESCRIPTION
This causes javadoc to fail, because a single < is not allowed in any
javadoc statement. Because javadoc is actually HTML. Our email addresses
are found on the Project page anyway.
