### PR TITLE
Enhancement/warning message

### DIFF
--- a/geex-core/geex-core.iml
+++ b/geex-core/geex-core.iml
@@ -26,5 +26,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: de.saxsys:jfx-testrunner:1.1" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
     <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.1" level="project" />
+    <orderEntry type="module" module-name="geex-logger" />
   </component>
 </module>

--- a/geex-core/geex-core.iml
+++ b/geex-core/geex-core.iml
@@ -20,12 +20,12 @@
     <orderEntry type="library" name="Maven: org.tmatesoft.sqljet:sqljet:1.1.10" level="project" />
     <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.4" level="project" />
     <orderEntry type="module" module-name="geex-effects" />
+    <orderEntry type="module" module-name="geex-logger" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.9.5" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: de.saxsys:jfx-testrunner:1.1" level="project" />
     <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
     <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.1" level="project" />
-    <orderEntry type="module" module-name="geex-logger" />
   </component>
 </module>

--- a/geex-core/pom.xml
+++ b/geex-core/pom.xml
@@ -36,5 +36,10 @@
             <artifactId>geex-effects</artifactId>
             <version>0.8</version>
         </dependency>
+        <dependency>
+            <groupId>nl.tudelft.context</groupId>
+            <artifactId>geex-logger</artifactId>
+            <version>0.8</version>
+        </dependency>
     </dependencies>
 </project>

--- a/geex-core/src/main/java/nl/tudelft/context/App.java
+++ b/geex-core/src/main/java/nl/tudelft/context/App.java
@@ -3,6 +3,9 @@ package nl.tudelft.context;
 import javafx.application.Application;
 import javafx.stage.Stage;
 import nl.tudelft.context.controller.MainController;
+import nl.tudelft.context.logger.Log;
+import nl.tudelft.context.logger.StdOutLogger;
+import nl.tudelft.context.logger.message.Message;
 import nl.tudelft.context.window.Window;
 
 /**
@@ -35,6 +38,11 @@ public class App extends Application {
      */
     @Override
     public final void start(final Stage stage) {
+        if (Boolean.getBoolean("debug")) {
+            new StdOutLogger(Log.instance());
+
+            Log.debug(Message.DEBUGGER_READY);
+        }
 
         MainController controller = new MainController();
         new Window("Geex", controller.getRoot());

--- a/geex-core/src/main/java/nl/tudelft/context/controller/GraphController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/GraphController.java
@@ -4,7 +4,8 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.MenuItem;
-import nl.tudelft.context.controller.message.Message;
+import nl.tudelft.context.logger.Log;
+import nl.tudelft.context.logger.message.Message;
 import nl.tudelft.context.drawable.graph.DrawableGraph;
 import nl.tudelft.context.model.annotation.AnnotationMap;
 import nl.tudelft.context.model.graph.CollapseGraph;
@@ -90,7 +91,7 @@ public final class GraphController extends AbstractGraphController {
         ObjectProperty<ResistanceMap> resistanceMapProperty = new SimpleObjectProperty<>();
 
         graphMapProperty.addListener(event -> {
-            mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_ANNOTATION);
+            Log.info(Message.SUCCESS_LOAD_ANNOTATION);
             loadGraph(graphMapProperty.get(), annotationMapProperty.get());
         });
         annotationMapProperty.addListener(event -> loadGraph(graphMapProperty.get(), annotationMapProperty.get()));
@@ -170,7 +171,7 @@ public final class GraphController extends AbstractGraphController {
      * @param resistanceMap The resistance map which is loaded.
      */
     private void loadResistance(final ResistanceMap resistanceMap) {
-        mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_RESISTANCE);
+        Log.info(Message.SUCCESS_LOAD_RESISTANCE);
     }
 
     @Override

--- a/geex-core/src/main/java/nl/tudelft/context/controller/GraphController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/GraphController.java
@@ -4,6 +4,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.MenuItem;
+import nl.tudelft.context.controller.message.Message;
 import nl.tudelft.context.drawable.graph.DrawableGraph;
 import nl.tudelft.context.model.annotation.AnnotationMap;
 import nl.tudelft.context.model.graph.CollapseGraph;
@@ -89,7 +90,7 @@ public final class GraphController extends AbstractGraphController {
         ObjectProperty<ResistanceMap> resistanceMapProperty = new SimpleObjectProperty<>();
 
         graphMapProperty.addListener(event -> {
-            mainController.displayMessage(MessageController.SUCCESS_LOAD_ANNOTATION);
+            mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_ANNOTATION);
             loadGraph(graphMapProperty.get(), annotationMapProperty.get());
         });
         annotationMapProperty.addListener(event -> loadGraph(graphMapProperty.get(), annotationMapProperty.get()));
@@ -169,7 +170,7 @@ public final class GraphController extends AbstractGraphController {
      * @param resistanceMap The resistance map which is loaded.
      */
     private void loadResistance(final ResistanceMap resistanceMap) {
-        mainController.displayMessage(MessageController.SUCCESS_LOAD_RESISTANCE);
+        mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_RESISTANCE);
     }
 
     @Override

--- a/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
@@ -263,13 +263,6 @@ public class MainController extends AbstractController<StackPane> {
     }
 
     /**
-     * Get a reference to the messageController.
-     */
-    public MessageController getMessageController() {
-        return messageController;
-    }
-
-    /**
      * Show the graph.
      *
      * @param on      Controller to place it on

--- a/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
@@ -263,12 +263,10 @@ public class MainController extends AbstractController<StackPane> {
     }
 
     /**
-     * The function that is used to display a message in the footer.
-     *
-     * @param text The text that will be displayed.
+     * Get a reference to the messageController.
      */
-    public void displayMessage(final String text) {
-        messageController.displayMessage(text);
+    public MessageController getMessageController() {
+        return messageController;
     }
 
     /**

--- a/geex-core/src/main/java/nl/tudelft/context/controller/MessageController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/MessageController.java
@@ -3,6 +3,8 @@ package nl.tudelft.context.controller;
 import javafx.fxml.FXML;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
+import nl.tudelft.context.controller.message.Message;
+import nl.tudelft.context.controller.message.MessageType;
 
 import java.net.URL;
 import java.util.ResourceBundle;
@@ -15,68 +17,6 @@ import java.util.ResourceBundle;
  */
 public class MessageController extends AbstractController<VBox> {
 
-    /**
-     * Message used when loading previous workspaces fails.
-     */
-    public static final String FAIL_LOAD_PREVIOUS = "Could not load previous workspaces.";
-
-    /**
-     * Message used when graph loading fails.
-     */
-    public static final String FAIL_LOAD_GRAPH = "Could not load genome graph.";
-
-    /**
-     * Message used when graph loading succeeds.
-     */
-    public static final String SUCCESS_LOAD_GRAPH = "Genome graph loaded successfully.";
-
-    /**
-     * Message used when workspace loading fails.
-     */
-    public static final String FAIL_LOAD_WORKSPACE = "Could not load workspace.";
-
-    /**
-     * Message used when workspace loading succeeds.
-     */
-    public static final String SUCCESS_LOAD_WORKSPACE = "Workspace loaded successfully.";
-
-    /**
-     * Message used when tree loading fails.
-     */
-    public static final String FAIL_LOAD_TREE = "Could not load phylogenetic tree.";
-
-    /**
-     * Message used when tree loading succeeds.
-     */
-    public static final String SUCCESS_LOAD_TREE = "Phylogenetic tree loaded successfully.";
-
-    /**
-     * Message used when annotation loading fails.
-     */
-    public static final String FAIL_LOAD_ANNOTATION = "Could not load annotations.";
-
-    /**
-     * Message used when annotation loading succeeds.
-     */
-    public static final String SUCCESS_LOAD_ANNOTATION = "Annotations loaded successfully.";
-    /**
-     * The text that is shown.
-     */
-
-    /**
-     * Message used when resistance loading fails.
-     */
-    public static final String FAIL_LOAD_RESISTANCE = "Could not load resistance annotations.";
-
-    /**
-     * Message used when annotation loading succeeds.
-     */
-    public static final String SUCCESS_LOAD_RESISTANCE = "Resistance Annotations loaded successfully.";
-
-    /**
-     * Message used when annotation loading succeeds.
-     */
-    public static final String FAIL_LOAD_RECENTWORKSPACE = "Could not load recent workspace.";
 
     /**
      * The text that is shown.
@@ -92,23 +32,34 @@ public class MessageController extends AbstractController<VBox> {
      * A reference to the main controller.
      */
     public MessageController() {
-
         super(new VBox());
 
         loadFXML("/application/footer.fxml");
     }
 
     /**
+     * Show a standard Info message.
+     *
+     * @param msg Message to display
+     */
+    public final void displayMessage(final Message msg) {
+        displayMessage(msg, MessageType.INFO);
+    }
+
+    /**
      * The function used to display a message and remove the previous one.
      *
-     * @param text The string to display.
+     * @param msg  Message to display.
+     * @param type Type of the message
      */
-    public final void displayMessage(final String text) {
-        message.setText(text);
+    public final void displayMessage(final Message msg, final MessageType type) {
+        root.getStyleClass().removeAll(MessageType.types());
+        root.getStyleClass().add(type.getType());
+        message.setText(msg.getMessage());
     }
 
     @Override
     public final void initialize(final URL location, final ResourceBundle resources) {
-        displayMessage("Ready");
+        displayMessage(Message.MESSAGE_READY);
     }
 }

--- a/geex-core/src/main/java/nl/tudelft/context/controller/MessageController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/MessageController.java
@@ -3,8 +3,10 @@ package nl.tudelft.context.controller;
 import javafx.fxml.FXML;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
-import nl.tudelft.context.controller.message.Message;
-import nl.tudelft.context.controller.message.MessageType;
+import nl.tudelft.context.logger.Log;
+import nl.tudelft.context.logger.Logger;
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
 
 import java.net.URL;
 import java.util.ResourceBundle;
@@ -12,12 +14,11 @@ import java.util.ResourceBundle;
 
 /**
  * @author Jim Hommes
- * @version 1.0
+ * @author Gerben Oolbekkink
+ * @version 2.0
  * @since 19-05-2015
  */
-public class MessageController extends AbstractController<VBox> {
-
-
+public class MessageController extends AbstractController<VBox> implements Logger {
     /**
      * The text that is shown.
      */
@@ -38,28 +39,23 @@ public class MessageController extends AbstractController<VBox> {
     }
 
     /**
-     * Show a standard Info message.
-     *
-     * @param msg Message to display
-     */
-    public final void displayMessage(final Message msg) {
-        displayMessage(msg, MessageType.INFO);
-    }
-
-    /**
      * The function used to display a message and remove the previous one.
      *
      * @param msg  Message to display.
-     * @param type Type of the message
+     * @param messageType Type of this message.
      */
-    public final void displayMessage(final Message msg, final MessageType type) {
+    public final void log(final Message msg, final MessageType messageType) {
         root.getStyleClass().removeAll(MessageType.types());
-        root.getStyleClass().add(type.getType());
-        message.setText(msg.getMessage());
+        root.getStyleClass().add(messageType.toString());
+        message.setText(msg.toString());
+    }
+
+    public final MessageType getLevel() {
+        return MessageType.INFO;
     }
 
     @Override
     public final void initialize(final URL location, final ResourceBundle resources) {
-        displayMessage(Message.MESSAGE_READY);
+        Log.instance().addLogger(this);
     }
 }

--- a/geex-core/src/main/java/nl/tudelft/context/controller/NewickController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/NewickController.java
@@ -3,6 +3,7 @@ package nl.tudelft.context.controller;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
+import nl.tudelft.context.controller.message.Message;
 import nl.tudelft.context.controller.search.NewickSearchController;
 import nl.tudelft.context.drawable.DrawableEdge;
 import nl.tudelft.context.drawable.DrawableNewick;
@@ -74,7 +75,7 @@ public final class NewickController extends AbstractNewickController {
                 newick.getRoot().getSelectionProperty().isEqualTo(new None()).or(activeProperty.not())
         );
 
-        mainController.displayMessage(MessageController.SUCCESS_LOAD_TREE);
+        mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_TREE);
 
         new NewickSearchController(nodeList, search, newickScroller);
     }

--- a/geex-core/src/main/java/nl/tudelft/context/controller/NewickController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/NewickController.java
@@ -3,7 +3,8 @@ package nl.tudelft.context.controller;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
-import nl.tudelft.context.controller.message.Message;
+import nl.tudelft.context.logger.Log;
+import nl.tudelft.context.logger.message.Message;
 import nl.tudelft.context.controller.search.NewickSearchController;
 import nl.tudelft.context.drawable.DrawableEdge;
 import nl.tudelft.context.drawable.DrawableNewick;
@@ -75,7 +76,7 @@ public final class NewickController extends AbstractNewickController {
                 newick.getRoot().getSelectionProperty().isEqualTo(new None()).or(activeProperty.not())
         );
 
-        mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_TREE);
+        Log.info(Message.SUCCESS_LOAD_TREE);
 
         new NewickSearchController(nodeList, search, newickScroller);
     }

--- a/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
@@ -11,7 +11,6 @@ import javafx.stage.DirectoryChooser;
 import javafx.stage.Window;
 import nl.tudelft.context.logger.Log;
 import nl.tudelft.context.logger.message.Message;
-import nl.tudelft.context.logger.message.MessageType;
 import nl.tudelft.context.workspace.Database;
 import nl.tudelft.context.workspace.Workspace;
 import org.tmatesoft.sqljet.core.SqlJetException;

--- a/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
@@ -9,8 +9,9 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.layout.GridPane;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.Window;
-import nl.tudelft.context.controller.message.Message;
-import nl.tudelft.context.controller.message.MessageType;
+import nl.tudelft.context.logger.Log;
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
 import nl.tudelft.context.workspace.Database;
 import nl.tudelft.context.workspace.Workspace;
 import org.tmatesoft.sqljet.core.SqlJetException;
@@ -99,7 +100,7 @@ public class WelcomeController extends ViewController<GridPane> {
                 previous.setDisable(true);
             }
         } catch (SqlJetException e) {
-            mainController.getMessageController().displayMessage(Message.FAIL_LOAD_PREVIOUS, MessageType.WARNING);
+            Log.instance().warning(Message.FAIL_LOAD_PREVIOUS);
             // Continue, this doesn't break the software.
         }
     }
@@ -150,13 +151,13 @@ public class WelcomeController extends ViewController<GridPane> {
 
             mainController.setWorkspace(workspace);
             mainController.setBaseView(new NewickController(mainController, workspace.getNewick()));
-            mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_WORKSPACE);
+            Log.info(Message.SUCCESS_LOAD_WORKSPACE);
         } catch (FileNotFoundException | SqlJetException ex) {
-            mainController.getMessageController().displayMessage(Message.FAIL_LOAD_WORKSPACE, MessageType.WARNING);
+            Log.warning(Message.FAIL_LOAD_WORKSPACE);
             try {
                 Database.instance().remove("workspace", directory.getAbsolutePath());
             } catch (SqlJetException | NullPointerException ignored) {
-                mainController.getMessageController().displayMessage(Message.FAIL_LOAD_RECENTWORKSPACE, MessageType.WARNING);
+                Log.warning(Message.FAIL_LOAD_RECENTWORKSPACE);
             }
         }
         reloadListView();

--- a/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/WelcomeController.java
@@ -9,6 +9,8 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.layout.GridPane;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.Window;
+import nl.tudelft.context.controller.message.Message;
+import nl.tudelft.context.controller.message.MessageType;
 import nl.tudelft.context.workspace.Database;
 import nl.tudelft.context.workspace.Workspace;
 import org.tmatesoft.sqljet.core.SqlJetException;
@@ -97,7 +99,7 @@ public class WelcomeController extends ViewController<GridPane> {
                 previous.setDisable(true);
             }
         } catch (SqlJetException e) {
-            mainController.displayMessage(MessageController.FAIL_LOAD_PREVIOUS);
+            mainController.getMessageController().displayMessage(Message.FAIL_LOAD_PREVIOUS, MessageType.WARNING);
             // Continue, this doesn't break the software.
         }
     }
@@ -148,13 +150,13 @@ public class WelcomeController extends ViewController<GridPane> {
 
             mainController.setWorkspace(workspace);
             mainController.setBaseView(new NewickController(mainController, workspace.getNewick()));
-            mainController.displayMessage(MessageController.SUCCESS_LOAD_WORKSPACE);
+            mainController.getMessageController().displayMessage(Message.SUCCESS_LOAD_WORKSPACE);
         } catch (FileNotFoundException | SqlJetException ex) {
-            mainController.displayMessage(MessageController.FAIL_LOAD_WORKSPACE);
+            mainController.getMessageController().displayMessage(Message.FAIL_LOAD_WORKSPACE, MessageType.WARNING);
             try {
                 Database.instance().remove("workspace", directory.getAbsolutePath());
             } catch (SqlJetException | NullPointerException ignored) {
-                mainController.displayMessage(MessageController.FAIL_LOAD_RECENTWORKSPACE);
+                mainController.getMessageController().displayMessage(Message.FAIL_LOAD_RECENTWORKSPACE, MessageType.WARNING);
             }
         }
         reloadListView();

--- a/geex-core/src/main/java/nl/tudelft/context/controller/message/Message.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/message/Message.java
@@ -1,0 +1,33 @@
+package nl.tudelft.context.controller.message;
+
+/**
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 13-6-2015
+ */
+public enum Message {
+    FAIL_LOAD_PREVIOUS("Could not load previous workspaces."),
+    FAIL_LOAD_GRAPH("Could not load genome graph."),
+    SUCCESS_LOAD_GRAPH("Genome graph loaded successfully."),
+    FAIL_LOAD_WORKSPACE("Could not load workspace."),
+    SUCCESS_LOAD_WORKSPACE("Workspace loaded successfully."),
+    FAIL_LOAD_TREE("Could not load phylogenetic tree."),
+    SUCCESS_LOAD_TREE("Phylogenetic tree loaded successfully."),
+    FAIL_LOAD_ANNOTATION("Could not load annotations."),
+    SUCCESS_LOAD_ANNOTATION("Annotations loaded successfully."),
+    FAIL_LOAD_RESISTANCE("Could not load resistance annotations."),
+    SUCCESS_LOAD_RESISTANCE("Resistance Annotations loaded successfully."),
+    FAIL_LOAD_RECENTWORKSPACE("Could not load recent workspace."),
+    MESSAGE_READY("Ready"),
+    ;
+
+    private String message;
+
+    Message(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/geex-core/src/main/java/nl/tudelft/context/controller/message/MessageType.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/message/MessageType.java
@@ -1,0 +1,30 @@
+package nl.tudelft.context.controller.message;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 13-6-2015
+ */
+public enum MessageType {
+    WARNING("warning"),
+    INFO("info");
+
+    private String type;
+
+    MessageType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public static List<String> types() {
+        return Arrays.stream(values()).map(MessageType::getType).collect(toList());
+    }
+}

--- a/geex-core/src/main/resources/application/css/footer.css
+++ b/geex-core/src/main/resources/application/css/footer.css
@@ -1,0 +1,19 @@
+/* Messages */
+#messageBox {
+    -fx-padding: 2px 7px;
+    -fx-border-width: 1px 0 0;
+    -fx-border-color: #848484;
+}
+
+#message {
+    -fx-font: 0.3cm 'Arial';
+    -fx-fill: #848484;
+}
+
+.info {
+    -fx-background-color: #2b2b2b;
+}
+
+.warning {
+    -fx-background-color: #9b0d00;
+}

--- a/geex-core/src/main/resources/application/css/style.css
+++ b/geex-core/src/main/resources/application/css/style.css
@@ -339,18 +339,6 @@
     -fx-padding: 10px;
 }
 
-/* Messages */
-#messageBox {
-    -fx-padding: 2px 7px;
-    -fx-border-width: 1px 0 0;
-    -fx-border-color: #848484;
-}
-
-#message {
-    -fx-font: 0.3cm 'Arial';
-    -fx-fill: #848484;
-}
-
 /* Breadcrumb */
 .breadcrumb {
     -fx-border-width: 0 0 1px;

--- a/geex-core/src/main/resources/application/footer.fxml
+++ b/geex-core/src/main/resources/application/footer.fxml
@@ -3,14 +3,10 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
 <?import java.net.URL?>
-<fx:root type="javafx.scene.layout.VBox" xmlns:fx="http://javafx.com/fxml">
-
-    <VBox fx:id="messageBox">
-        <Text fx:id="message"/>
-    </VBox>
+<fx:root type="javafx.scene.layout.VBox" styleClass="info" xmlns:fx="http://javafx.com/fxml">
+    <Text fx:id="message"/>
 
     <stylesheets>
-        <URL value="@css/style.css"/>
+        <URL value="@css/footer.css"/>
     </stylesheets>
-
 </fx:root>

--- a/geex-core/src/main/resources/application/footer.fxml
+++ b/geex-core/src/main/resources/application/footer.fxml
@@ -3,7 +3,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
 <?import java.net.URL?>
-<fx:root type="javafx.scene.layout.VBox" styleClass="info" xmlns:fx="http://javafx.com/fxml">
+<fx:root type="javafx.scene.layout.VBox" fx:id="messageBox" styleClass="info" xmlns:fx="http://javafx.com/fxml">
     <Text fx:id="message"/>
 
     <stylesheets>

--- a/geex-core/src/test/java/nl/tudelft/context/controller/MainControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/MainControllerTest.java
@@ -137,20 +137,6 @@ public class MainControllerTest {
     }
 
     /**
-     * Test viewing text.
-     */
-    @Test
-    public void testFooterText() {
-        MainController mc = new MainController();
-        mc.setWorkspace(workspace);
-
-        String text = "This is a test.";
-        mc.displayMessage(text);
-
-        assertEquals(mc.messageController.message.getText(), text);
-    }
-
-    /**
      * Test the workspace getter.
      */
     @Test

--- a/geex-core/src/test/java/nl/tudelft/context/controller/MessageControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/MessageControllerTest.java
@@ -2,6 +2,7 @@ package nl.tudelft.context.controller;
 
 import de.saxsys.javafx.test.JfxRunner;
 import javafx.scene.text.Text;
+import nl.tudelft.context.controller.message.Message;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -21,12 +22,10 @@ public class MessageControllerTest {
     @Test
     public void testDisplayText() {
         MessageController mc = new MessageController();
-        String text = "Display Test";
+        String text = Message.MESSAGE_READY.getMessage();
 
-        mc.displayMessage(text);
+        mc.displayMessage(Message.MESSAGE_READY);
 
         assertEquals(mc.message.getText(), text);
     }
-
-
 }

--- a/geex-core/src/test/java/nl/tudelft/context/controller/MessageControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/MessageControllerTest.java
@@ -1,8 +1,8 @@
 package nl.tudelft.context.controller;
 
 import de.saxsys.javafx.test.JfxRunner;
-import javafx.scene.text.Text;
-import nl.tudelft.context.controller.message.Message;
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -24,7 +24,7 @@ public class MessageControllerTest {
         MessageController mc = new MessageController();
         String text = Message.MESSAGE_READY.getMessage();
 
-        mc.displayMessage(Message.MESSAGE_READY);
+        mc.log(Message.MESSAGE_READY, MessageType.INFO);
 
         assertEquals(mc.message.getText(), text);
     }

--- a/geex-core/src/test/java/nl/tudelft/context/controller/MessageControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/MessageControllerTest.java
@@ -22,7 +22,7 @@ public class MessageControllerTest {
     @Test
     public void testDisplayText() {
         MessageController mc = new MessageController();
-        String text = Message.MESSAGE_READY.getMessage();
+        String text = Message.MESSAGE_READY.toString();
 
         mc.log(Message.MESSAGE_READY, MessageType.INFO);
 

--- a/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
@@ -41,6 +41,7 @@ public class NewickControllerTest {
         when(mainController.getMenuController()).thenReturn(new MenuController(mainController, new MenuBar()));
 
         Workspace workspace = mock(Workspace.class);
+        MessageController messageController = mock(MessageController.class);
 
         when(workspace.getGraph()).thenReturn(new SimpleObjectProperty<>());
         when(workspace.getAnnotation()).thenReturn(new SimpleObjectProperty<>());
@@ -48,6 +49,7 @@ public class NewickControllerTest {
         when(workspace.getResistance()).thenReturn(new SimpleObjectProperty<>());
 
         when(mainController.getWorkspace()).thenReturn(workspace);
+        when(mainController.getMessageController()).thenReturn(messageController);
 
         Newick newick = new Newick();
         AbstractNode node = new StrandNode("n1", 1.23);
@@ -71,7 +73,7 @@ public class NewickControllerTest {
         newick.setRoot(node);
         newick.addVertex(node);
         newickController.showTree(newick);
-        verify(mainController, atLeast(1)).displayMessage(MessageController.SUCCESS_LOAD_TREE);
+        verify(mainController, atLeast(1)).getMessageController();
     }
 
     /**

--- a/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
@@ -49,7 +49,6 @@ public class NewickControllerTest {
         when(workspace.getResistance()).thenReturn(new SimpleObjectProperty<>());
 
         when(mainController.getWorkspace()).thenReturn(workspace);
-        when(mainController.getMessageController()).thenReturn(messageController);
 
         Newick newick = new Newick();
         AbstractNode node = new StrandNode("n1", 1.23);
@@ -73,7 +72,7 @@ public class NewickControllerTest {
         newick.setRoot(node);
         newick.addVertex(node);
         newickController.showTree(newick);
-        verify(mainController, atLeast(1)).getMessageController();
+        //verify(mainController, atLeast(1)).getMessageController();
     }
 
     /**

--- a/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
+++ b/geex-core/src/test/java/nl/tudelft/context/controller/NewickControllerTest.java
@@ -63,19 +63,6 @@ public class NewickControllerTest {
     }
 
     /**
-     * MainController should receive a message that the tree is loaded.
-     */
-    @Test
-    public void testMessageTreeLoaded() {
-        Newick newick = new Newick();
-        AbstractNode node = new StrandNode("a", 1);
-        newick.setRoot(node);
-        newick.addVertex(node);
-        newickController.showTree(newick);
-        //verify(mainController, atLeast(1)).getMessageController();
-    }
-
-    /**
      * Test RuntimeException on wrong FXML file.
      */
     @Test(expected = RuntimeException.class)

--- a/geex-logger/geex-logger.iml
+++ b/geex-logger/geex-logger.iml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.9.5" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: de.saxsys:jfx-testrunner:1.1" level="project" />
+    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.6" level="project" />
+    <orderEntry type="library" name="Maven: commons-collections:commons-collections:3.2.1" level="project" />
+  </component>
+</module>

--- a/geex-logger/pom.xml
+++ b/geex-logger/pom.xml
@@ -9,7 +9,9 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>Geex Logger</name>
+
+    <description>Logger package for the Geex project.</description>
+
     <artifactId>geex-logger</artifactId>
-
-
 </project>

--- a/geex-logger/pom.xml
+++ b/geex-logger/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>geex</artifactId>
+        <groupId>nl.tudelft.context</groupId>
+        <version>0.8</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>geex-logger</artifactId>
+
+
+</project>

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/Log.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/Log.java
@@ -1,0 +1,65 @@
+package nl.tudelft.context.logger;
+
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+public class Log implements ObservableLog {
+
+    private static volatile Log instance;
+
+    /**
+     * Get or Create the logger.
+     *
+     * @return The logger for this application.
+     */
+    public static Log instance() {
+        if (instance == null) {
+            synchronized (Log.class) {
+                if (instance == null) {
+                    instance = new Log();
+                }
+            }
+        }
+        return instance;
+    }
+
+    private Log() {
+        listeners = new ArrayList<>();
+    }
+
+    List<Logger> listeners;
+
+    public void addLogger(Logger listener) {
+        listeners.add(listener);
+    }
+
+    public void removeLogger(Logger listener) {
+        listeners.remove(listener);
+    }
+
+    public static void info(Message message) {
+        instance().message(message, MessageType.INFO);
+    }
+
+    public static void warning(Message message) {
+        instance().message(message, MessageType.WARNING);
+    }
+
+    public static void debug(Message message) {
+        instance().message(message, MessageType.DEBUG);
+    }
+
+    public void message(Message message, MessageType type) {
+        listeners.stream()
+                .filter(logger -> logger.getLevel().getLevel() <= type.getLevel())
+                .forEach(logger -> logger.log(message, type));
+    }
+}

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/Log.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/Log.java
@@ -7,12 +7,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * Concrete Log class for Geex.
+ *
  * @author Gerben Oolbekkink
  * @version 1.0
  * @since 14-6-2015
  */
-public class Log implements ObservableLog {
-
+public final class Log implements ObservableLog {
+    /**
+     * Instance of the singleton log.
+     */
     private static volatile Log instance;
 
     /**
@@ -31,33 +35,69 @@ public class Log implements ObservableLog {
         return instance;
     }
 
+    /**
+     * Create a new Log.
+     */
     private Log() {
         listeners = new ArrayList<>();
     }
 
+    /**
+     * The current loggers to log to.
+     */
     List<Logger> listeners;
 
-    public void addLogger(Logger listener) {
+    /**
+     * Register a new logger.
+     * @param listener logger to register.
+     */
+    public void addLogger(final Logger listener) {
         listeners.add(listener);
     }
 
-    public void removeLogger(Logger listener) {
+    /**
+     * Remove an existing logger.
+     *
+     * @param listener logger to remove.
+     */
+    public void removeLogger(final Logger listener) {
         listeners.remove(listener);
     }
 
-    public static void info(Message message) {
+    /**
+     * Log a message of type {@link MessageType}.INFO.
+     *
+     * @param message Message to log.
+     */
+    public static void info(final Message message) {
         instance().message(message, MessageType.INFO);
     }
 
-    public static void warning(Message message) {
+    /**
+     * Log a message of type {@link MessageType}.WARNING.
+     *
+     * @param message Message to log.
+     */
+    public static void warning(final Message message) {
         instance().message(message, MessageType.WARNING);
     }
 
-    public static void debug(Message message) {
+    /**
+     * Log a message of type {@link MessageType}.DEBUG.
+     *
+     * @param message Message to log.
+     */
+    public static void debug(final Message message) {
         instance().message(message, MessageType.DEBUG);
     }
 
-    public void message(Message message, MessageType type) {
+    /**
+     * Notify listeners which qualify to the type.
+     *
+     * @param message Message to log
+     * @param type Type of message
+     */
+    private void message(final Message message, final MessageType type) {
         listeners.stream()
                 .filter(logger -> logger.getLevel().getLevel() <= type.getLevel())
                 .forEach(logger -> logger.log(message, type));

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/Logger.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/Logger.java
@@ -1,0 +1,14 @@
+package nl.tudelft.context.logger;
+
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
+
+/**
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+public interface Logger {
+    MessageType getLevel();
+    void log(Message message, MessageType messageType);
+}

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/Logger.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/Logger.java
@@ -9,6 +9,20 @@ import nl.tudelft.context.logger.message.MessageType;
  * @since 14-6-2015
  */
 public interface Logger {
-    MessageType getLevel();
+    /**
+     * Function used when a log message is to be shown.
+     *
+     * @param message Message to show
+     * @param messageType Type of this message
+     */
     void log(Message message, MessageType messageType);
+
+    /**
+     * The ObservableLogger looks at this to choose if a log message is relevant for this Logger.
+     *
+     * This level and levels worse are included.
+     *
+     * @return The level relevant for this logger.
+     */
+    MessageType getLevel();
 }

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/ObservableLog.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/ObservableLog.java
@@ -1,11 +1,26 @@
 package nl.tudelft.context.logger;
 
 /**
+ * Interface for the Log class.
+ *
+ * Any log implementation should implement this interface.
+ *
  * @author Gerben Oolbekkink
  * @version 1.0
  * @since 14-6-2015
  */
 public interface ObservableLog {
+    /**
+     * Add a logger to be called when a log occurs.
+     *
+     * @param logger Logger to add
+     */
     void addLogger(Logger logger);
+
+    /**
+     * Remove a logger from the current loggers.
+     *
+     * @param logger Logger to remove
+     */
     void removeLogger(Logger logger);
 }

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/ObservableLog.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/ObservableLog.java
@@ -1,0 +1,11 @@
+package nl.tudelft.context.logger;
+
+/**
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+public interface ObservableLog {
+    void addLogger(Logger logger);
+    void removeLogger(Logger logger);
+}

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
@@ -14,18 +14,28 @@ import java.sql.Timestamp;
  * @since 14-6-2015
  */
 public class StdOutLogger implements Logger {
-    public StdOutLogger(ObservableLog log) {
+    /**
+     * Create a new StdOutLogger.
+     *
+     * @param log Log to observe.
+     */
+    public StdOutLogger(final ObservableLog log) {
         log.addLogger(this);
     }
 
     @Override
-    public void log(Message message, MessageType messageType) {
+    public void log(final Message message, final MessageType messageType) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
 
         getStream(messageType).printf("%-23s [%s] %s%n", timestamp, messageType, message);
     }
 
-    PrintStream getStream(MessageType type) {
+    /**
+     * Get a proper stream for each {@link MessageType}.
+     * @param type MessageType which is logged
+     * @return A PrintStream for this type of message
+     */
+    PrintStream getStream(final MessageType type) {
         if (type == MessageType.WARNING) {
             return System.err;
         }

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
@@ -13,7 +13,7 @@ import java.sql.Timestamp;
  * @version 1.0
  * @since 14-6-2015
  */
-public class StdOutLogger implements Logger {
+public final class StdOutLogger implements Logger {
     /**
      * Create a new StdOutLogger.
      *

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
@@ -22,7 +22,7 @@ public class StdOutLogger implements Logger {
     public void log(Message message, MessageType messageType) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
 
-        getStream(messageType).printf("%-23s [%s] %s\n", timestamp, messageType, message);
+        getStream(messageType).printf("%-23s [%s] %s%n", timestamp, messageType, message);
     }
 
     PrintStream getStream(MessageType type) {

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/StdOutLogger.java
@@ -1,0 +1,40 @@
+package nl.tudelft.context.logger;
+
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
+
+import java.io.PrintStream;
+import java.sql.Timestamp;
+
+/**
+ * Register as logger and write log messages to stdout.
+ *
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+public class StdOutLogger implements Logger {
+    public StdOutLogger(ObservableLog log) {
+        log.addLogger(this);
+    }
+
+    @Override
+    public void log(Message message, MessageType messageType) {
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+
+        getStream(messageType).printf("%-23s [%s] %s\n", timestamp, messageType, message);
+    }
+
+    PrintStream getStream(MessageType type) {
+        if (type == MessageType.WARNING) {
+            return System.err;
+        }
+
+        return System.out;
+    }
+
+    @Override
+    public MessageType getLevel() {
+        return MessageType.DEBUG;
+    }
+}

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/message/Message.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/message/Message.java
@@ -1,4 +1,4 @@
-package nl.tudelft.context.controller.message;
+package nl.tudelft.context.logger.message;
 
 /**
  * @author Gerben Oolbekkink
@@ -19,7 +19,7 @@ public enum Message {
     SUCCESS_LOAD_RESISTANCE("Resistance Annotations loaded successfully."),
     FAIL_LOAD_RECENTWORKSPACE("Could not load recent workspace."),
     MESSAGE_READY("Ready"),
-    ;
+    DEBUGGER_READY("Debug logger ready.");
 
     private String message;
 
@@ -28,6 +28,11 @@ public enum Message {
     }
 
     public String getMessage() {
+        return message;
+    }
+
+    @Override
+    public String toString() {
         return message;
     }
 }

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/message/Message.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/message/Message.java
@@ -6,29 +6,91 @@ package nl.tudelft.context.logger.message;
  * @since 13-6-2015
  */
 public enum Message {
+    /**
+     * Message used when loading previous workspaces fails.
+     */
     FAIL_LOAD_PREVIOUS("Could not load previous workspaces."),
-    FAIL_LOAD_GRAPH("Could not load genome graph."),
-    SUCCESS_LOAD_GRAPH("Genome graph loaded successfully."),
-    FAIL_LOAD_WORKSPACE("Could not load workspace."),
-    SUCCESS_LOAD_WORKSPACE("Workspace loaded successfully."),
-    FAIL_LOAD_TREE("Could not load phylogenetic tree."),
-    SUCCESS_LOAD_TREE("Phylogenetic tree loaded successfully."),
-    FAIL_LOAD_ANNOTATION("Could not load annotations."),
-    SUCCESS_LOAD_ANNOTATION("Annotations loaded successfully."),
-    FAIL_LOAD_RESISTANCE("Could not load resistance annotations."),
-    SUCCESS_LOAD_RESISTANCE("Resistance Annotations loaded successfully."),
-    FAIL_LOAD_RECENTWORKSPACE("Could not load recent workspace."),
-    MESSAGE_READY("Ready"),
-    DEBUGGER_READY("Debug logger ready.");
 
+    /**
+     * Message used when graph loading fails.
+     */
+    FAIL_LOAD_GRAPH("Could not load genome graph."),
+
+    /**
+     * Message used when graph loading succeeds.
+     */
+    SUCCESS_LOAD_GRAPH("Genome graph loaded successfully."),
+
+    /**
+     * Message used when workspace loading fails.
+     */
+    FAIL_LOAD_WORKSPACE("Could not load workspace."),
+
+    /**
+     * Message used when workspace loading succeeds.
+     */
+    SUCCESS_LOAD_WORKSPACE("Workspace loaded successfully."),
+
+    /**
+     * Message used when tree loading fails.
+     */
+    FAIL_LOAD_TREE("Could not load phylogenetic tree."),
+
+    /**
+     * Message used when tree loading succeeds.
+     */
+    SUCCESS_LOAD_TREE("Phylogenetic tree loaded successfully."),
+
+    /**
+     * Message used when annotation loading fails.
+     */
+    FAIL_LOAD_ANNOTATION("Could not load annotations."),
+
+    /**
+     * Message used when annotation loading succeeds.
+     */
+    SUCCESS_LOAD_ANNOTATION("Annotations loaded successfully."),
+    /**
+     * The text that is shown.
+     */
+
+    /**
+     * Message used when resistance loading fails.
+     */
+    FAIL_LOAD_RESISTANCE("Could not load resistance annotations."),
+
+    /**
+     * Message used when annotation loading succeeds.
+     */
+    SUCCESS_LOAD_RESISTANCE("Resistance Annotations loaded successfully."),
+
+    /**
+     * Message used when annotation loading succeeds.
+     */
+    FAIL_LOAD_RECENTWORKSPACE("Could not load recent workspace."),
+
+    /**
+     * Message used when the application is ready.
+     */
+    MESSAGE_READY("Ready"),
+
+    /**
+     * Message used to show debugging is enabled.
+     */
+    DEBUGGER_READY("Debug logger enabled.");
+
+    /**
+     * Message string in this message.
+     */
     private String message;
 
-    Message(String message) {
+    /**
+     * Create a new Message.
+     *
+     * @param message Message string
+     */
+    Message(final String message) {
         this.message = message;
-    }
-
-    public String getMessage() {
-        return message;
     }
 
     @Override

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/message/MessageType.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/message/MessageType.java
@@ -1,4 +1,4 @@
-package nl.tudelft.context.controller.message;
+package nl.tudelft.context.logger.message;
 
 import java.util.Arrays;
 import java.util.List;
@@ -10,13 +10,17 @@ import static java.util.stream.Collectors.toList;
  * @version 1.0
  * @since 13-6-2015
  */
-public enum MessageType {
-    WARNING("warning"),
-    INFO("info");
+public enum MessageType implements Comparable<MessageType> {
+    WARNING(3, "warning"),
+    INFO(2, "info"),
+    DEBUG(1, "debug"),
+    ;
 
+    private int level;
     private String type;
 
-    MessageType(String type) {
+    MessageType(int level, String type) {
+        this.level = level;
         this.type = type;
     }
 
@@ -24,7 +28,16 @@ public enum MessageType {
         return type;
     }
 
+    public int getLevel() {
+        return level;
+    }
+
     public static List<String> types() {
         return Arrays.stream(values()).map(MessageType::getType).collect(toList());
+    }
+
+    @Override
+    public String toString() {
+        return type;
     }
 }

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/message/MessageType.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/message/MessageType.java
@@ -11,29 +11,61 @@ import static java.util.stream.Collectors.toList;
  * @since 13-6-2015
  */
 public enum MessageType implements Comparable<MessageType> {
+    /**
+     * Used when showing a warning message.
+     *
+     * A warning message implies that the software had to stop.
+     */
     WARNING(3, "warning"),
+    /**
+     * Used when showing an info message.
+     *
+     * Info messages are used to tell the user that something happened.
+     */
     INFO(2, "info"),
-    DEBUG(1, "debug"),
-    ;
+    /**
+     * Used when showing a debug message.
+     *
+     * Debug messages are used when something goes wrong and is must be debugged.
+     */
+    DEBUG(1, "debug");
 
+    /**
+     * Loglevel of this MessageType.
+     */
     private int level;
+    /**
+     * Type of this MessageType.
+     */
     private String type;
 
-    MessageType(int level, String type) {
+    /**
+     * Create a new MessageType.
+     *
+     * @param level LogLevel of this MessageType
+     * @param type Type name of this MessageType
+     */
+    MessageType(final int level, final String type) {
         this.level = level;
         this.type = type;
     }
 
-    public String getType() {
-        return type;
-    }
-
+    /**
+     * Get the log-level of this MessageType.
+     *
+     * @return log-level
+     */
     public int getLevel() {
         return level;
     }
 
+    /**
+     * Get a list of available types.
+     *
+     * @return List of types in MessageType
+     */
     public static List<String> types() {
-        return Arrays.stream(values()).map(MessageType::getType).collect(toList());
+        return Arrays.stream(values()).map(MessageType::toString).collect(toList());
     }
 
     @Override

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/message/package-info.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/message/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Package containing all Messages and MessageTypes.
+ *
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+package nl.tudelft.context.logger.message;

--- a/geex-logger/src/main/java/nl/tudelft/context/logger/package-info.java
+++ b/geex-logger/src/main/java/nl/tudelft/context/logger/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Package containing the logger class and interfaces.
+ *
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+package nl.tudelft.context.logger;

--- a/geex-logger/src/test/java/nl/tudelft/context/logger/LogTest.java
+++ b/geex-logger/src/test/java/nl/tudelft/context/logger/LogTest.java
@@ -1,0 +1,94 @@
+package nl.tudelft.context.logger;
+
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+public class LogTest {
+    @Test
+    public void testInstance() {
+        assertEquals(Log.instance(), Log.instance());
+    }
+
+    @Test
+     public void testDebugLogger() {
+        Logger logger = mock(Logger.class);
+
+        when(logger.getLevel()).thenReturn(MessageType.DEBUG);
+
+        Log.instance().addLogger(logger);
+
+        Log.info(Message.MESSAGE_READY);
+        verify(logger).log(Message.MESSAGE_READY, MessageType.INFO);
+
+        Log.debug(Message.MESSAGE_READY);
+        verify(logger).log(Message.MESSAGE_READY, MessageType.DEBUG);
+
+        Log.warning(Message.MESSAGE_READY);
+        verify(logger).log(Message.MESSAGE_READY, MessageType.WARNING);
+    }
+
+    @Test
+    public void testInfoLogger() {
+        Logger logger = mock(Logger.class);
+
+        when(logger.getLevel()).thenReturn(MessageType.INFO);
+
+        Log.instance().addLogger(logger);
+
+        Log.info(Message.MESSAGE_READY);
+        verify(logger).log(Message.MESSAGE_READY, MessageType.INFO);
+
+        Log.debug(Message.MESSAGE_READY);
+        verify(logger, never()).log(Message.MESSAGE_READY, MessageType.DEBUG);
+
+        Log.warning(Message.MESSAGE_READY);
+        verify(logger).log(Message.MESSAGE_READY, MessageType.WARNING);
+    }
+
+    @Test
+    public void testWarningLogger() {
+        Logger logger = mock(Logger.class);
+
+        when(logger.getLevel()).thenReturn(MessageType.WARNING);
+
+        Log.instance().addLogger(logger);
+
+        Log.info(Message.MESSAGE_READY);
+        verify(logger, never()).log(Message.MESSAGE_READY, MessageType.INFO);
+
+        Log.debug(Message.MESSAGE_READY);
+        verify(logger, never()).log(Message.MESSAGE_READY, MessageType.DEBUG);
+
+        Log.warning(Message.MESSAGE_READY);
+        verify(logger).log(Message.MESSAGE_READY, MessageType.WARNING);
+    }
+
+    @Test
+    public void testRemoveLogger() {
+        Logger logger = mock(Logger.class);
+
+        when(logger.getLevel()).thenReturn(MessageType.DEBUG);
+
+        Log.instance().addLogger(logger);
+
+        Log.info(Message.MESSAGE_READY);
+        verify(logger).log(Message.MESSAGE_READY, MessageType.INFO);
+
+        Log.instance().removeLogger(logger);
+
+        Log.debug(Message.MESSAGE_READY);
+        verify(logger, never()).log(Message.MESSAGE_READY, MessageType.DEBUG);
+    }
+}

--- a/geex-logger/src/test/java/nl/tudelft/context/logger/StdOutLoggerTest.java
+++ b/geex-logger/src/test/java/nl/tudelft/context/logger/StdOutLoggerTest.java
@@ -1,0 +1,67 @@
+package nl.tudelft.context.logger;
+
+import nl.tudelft.context.logger.message.Message;
+import nl.tudelft.context.logger.message.MessageType;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Gerben Oolbekkink
+ * @version 1.0
+ * @since 14-6-2015
+ */
+public class StdOutLoggerTest {
+
+    @Test
+    public void testGetStream() throws Exception {
+        StdOutLogger logger = new StdOutLogger(mock(ObservableLog.class));
+
+        assertEquals(System.out, logger.getStream(MessageType.DEBUG));
+        assertEquals(System.out, logger.getStream(MessageType.INFO));
+        assertEquals(System.err, logger.getStream(MessageType.WARNING));
+    }
+
+    @Test
+    public void testDebugLog() throws Exception {
+        Logger logger = new StdOutLogger(mock(ObservableLog.class));
+
+        logger.log(Message.MESSAGE_READY, MessageType.DEBUG);
+
+        assertThat(outContent.toString(), CoreMatchers.containsString("[" + MessageType.DEBUG + "] " + Message.MESSAGE_READY));
+    }
+
+    @Test
+    public void testWarningLog() throws Exception {
+        Logger logger = new StdOutLogger(mock(ObservableLog.class));
+
+        logger.log(Message.MESSAGE_READY, MessageType.WARNING);
+
+        assertThat(errContent.toString(), CoreMatchers.containsString("[" + MessageType.WARNING + "] " + Message.MESSAGE_READY));
+    }
+
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+
+    @Before
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @After
+    public void cleanUpStreams() {
+        System.setOut(null);
+        System.setErr(null);
+    }
+
+}

--- a/geex-logger/src/test/java/nl/tudelft/context/logger/StdOutLoggerTest.java
+++ b/geex-logger/src/test/java/nl/tudelft/context/logger/StdOutLoggerTest.java
@@ -48,6 +48,12 @@ public class StdOutLoggerTest {
         assertThat(errContent.toString(), CoreMatchers.containsString("[" + MessageType.WARNING + "] " + Message.MESSAGE_READY));
     }
 
+    @Test
+    public void testLevel() throws Exception {
+        Logger logger = new StdOutLogger(mock(ObservableLog.class));
+        assertEquals(MessageType.DEBUG, logger.getLevel());
+    }
+
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
                 </dependencies>
                 <executions>
                     <execution>
+                        <inherited>false</inherited>
                         <phase>pre-site</phase>
                         <goals>
                             <goal>generate</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
         <module>geex-services</module>
         <module>geex-workspace</module>
         <module>geex-effects</module>
+        <module>geex-logger</module>
     </modules>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
                 </dependencies>
                 <executions>
                     <execution>
-                        <inherited>false</inherited>
                         <phase>pre-site</phase>
                         <goals>
                             <goal>generate</goal>

--- a/src/site/diagrams/geex-logger.puml
+++ b/src/site/diagrams/geex-logger.puml
@@ -1,0 +1,41 @@
+@startuml
+
+interface ObservableLog {
+    addLogger(logger : Logger)
+    removeLogger(logger : Logger)
+}
+class Log implements ObservableLog {
+    -{static}instance
+    -listeners : List<Logger>
+
+    +{static}instance()
+    +{static}info(message : Message)
+    +{static}warning(message : Message)
+    +{static}debug(message : Message)
+    -message(message : Message, type : MessageType)
+}
+
+interface Logger {
+    log(message : Message, messageType : MessageType)
+    getLevel() : MessageType
+}
+class StdOutLogger implements Logger {
+    getStream(type : MessageType) : PrintStream
+}
+
+enum Message {
+    -message : String
+}
+enum MessageType {
+    -type : String
+    -level : int
+}
+
+Logger --> Message
+Logger --> MessageType
+
+Log --> Message
+Log --> MessageType
+
+ObservableLog <-- Logger : observes
+@enduml

--- a/src/site/diagrams/modules.puml
+++ b/src/site/diagrams/modules.puml
@@ -4,6 +4,7 @@
 [geex-core] --> [geex-workspace]
 [geex-core] --> [geex-models]
 [geex-core] --> [geex-services]
+[geex-core] --> [geex-logger]
 
 [geex-models] --> [geex-services]
 

--- a/src/site/xhtml/architecture.xhtml
+++ b/src/site/xhtml/architecture.xhtml
@@ -16,6 +16,8 @@
 <a href="images/diagrams/geex-core.png"><img src="images/diagrams/geex-core.png" alt="Geex Core UML Diagram"/></a>
 <h2>Geex Effects</h2>
 <a href="images/diagrams/geex-effects.png"><img src="images/diagrams/geex-effects.png" alt="Geex Core UML Diagram"/></a>
+<h2>Geex Logger</h2>
+<a href="images/diagrams/geex-logger.png"><img src="images/diagrams/geex-logger.png" alt="Geex Logger UML Diagram"/></a>
 <h2>Geex Models</h2>
 <a href="images/diagrams/geex-models.png"><img src="images/diagrams/geex-models.png" alt="Geex Core UML Diagram"/></a>
 <h2>Geex Services</h2>


### PR DESCRIPTION
When a warning message is created, color the messageBar red.

Also implemented a small logger.

When running the application with `-Ddebug=true` the debug logger is enabled, which is called `StdOutLogger`.

To create a new logger, implement the interface `Logger`. Then in the constructor or the initialize observe the main Logger:

```
class FileLogger implements Logger {
    public FileLogger(ObservableLog log) {
        log.addLogger(this);
    }

    ...
}
```

The loglevel of a specific logger is set by implementing `getLevel()`. Every level greater than or equal to that level will be logged to this logger.
