### PR TITLE
Bug/workspace switch

### DIFF
--- a/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
+++ b/geex-core/src/main/java/nl/tudelft/context/controller/MainController.java
@@ -258,6 +258,9 @@ public class MainController extends AbstractController<StackPane> {
      * @param workspace The new workspace
      */
     public final void setWorkspace(final Workspace workspace) {
+        if (this.workspace != null) {
+            this.workspace.close();
+        }
         this.workspace = workspace;
         workspace.preload();
     }

--- a/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
@@ -21,7 +21,10 @@ public abstract class Parser<T> implements Loadable<T> {
      */
     BufferedReader[] readerList;
 
-    protected boolean cancelled = false;
+    /**
+     * The state of this parser.
+     */
+    private boolean cancelled = false;
 
     /**
      * Empty constructor for child classes which extend functionality.
@@ -48,8 +51,15 @@ public abstract class Parser<T> implements Loadable<T> {
         return this;
     }
 
+    /**
+     * Set the state of this parser to cancelled.
+     */
     public void cancelled() {
         this.cancelled = true;
+    }
+
+    protected boolean isCancelled() {
+        return cancelled;
     }
 
     /**

--- a/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
@@ -58,6 +58,10 @@ public abstract class Parser<T> implements Loadable<T> {
         this.cancelled = true;
     }
 
+    /**
+     * Check the state of the Parser.
+     * @return If the parser is cancelled
+     */
     protected boolean isCancelled() {
         return cancelled;
     }

--- a/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/Parser.java
@@ -21,6 +21,8 @@ public abstract class Parser<T> implements Loadable<T> {
      */
     BufferedReader[] readerList;
 
+    protected boolean cancelled = false;
+
     /**
      * Empty constructor for child classes which extend functionality.
      */
@@ -44,6 +46,10 @@ public abstract class Parser<T> implements Loadable<T> {
         }
 
         return this;
+    }
+
+    public void cancelled() {
+        this.cancelled = true;
     }
 
     /**

--- a/geex-models/src/main/java/nl/tudelft/context/model/annotation/AnnotationParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/annotation/AnnotationParser.java
@@ -25,7 +25,7 @@ public class AnnotationParser extends Parser<AnnotationMap> {
         AnnotationMap annotationMap = new AnnotationMap();
         String line;
         String fileSplitBy = "\\t";
-        while (sc.hasNextLine() && !cancelled) {
+        while (sc.hasNextLine() && !isCancelled()) {
             line = sc.nextLine();
             String[] splitLine = line.split(fileSplitBy);
             annotationMap.addAnnotation(getAnnotation(splitLine));
@@ -53,7 +53,6 @@ public class AnnotationParser extends Parser<AnnotationMap> {
         char phase = splitLine[++index].charAt(0);
         String attributes = splitLine[++index];
 
-        Annotation annotation = new Annotation(seqId, source, type, start, end, score, strand, phase, attributes);
-        return annotation;
+        return new Annotation(seqId, source, type, start, end, score, strand, phase, attributes);
     }
 }

--- a/geex-models/src/main/java/nl/tudelft/context/model/annotation/AnnotationParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/annotation/AnnotationParser.java
@@ -25,7 +25,7 @@ public class AnnotationParser extends Parser<AnnotationMap> {
         AnnotationMap annotationMap = new AnnotationMap();
         String line;
         String fileSplitBy = "\\t";
-        while (sc.hasNextLine()) {
+        while (sc.hasNextLine() && !cancelled) {
             line = sc.nextLine();
             String[] splitLine = line.split(fileSplitBy);
             annotationMap.addAnnotation(getAnnotation(splitLine));

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphParser.java
@@ -43,7 +43,7 @@ public final class GraphParser extends Parser<GraphMap> {
         NodeParser nodeParser = new NodeParser();
         List<Node> nodes = new ArrayList<>();
 
-        while (sc.hasNext()) {
+        while (sc.hasNext() && !cancelled) {
             Node n = nodeParser.getNode(sc);
             nodes.add(n);
             graphMap.addVertex(n);
@@ -65,7 +65,7 @@ public final class GraphParser extends Parser<GraphMap> {
 
         Scanner sc = new Scanner(edgeReader);
 
-        while (sc.hasNext()) {
+        while (sc.hasNext() && !cancelled) {
             graphMap.addEdge(nodeList.get(sc.nextInt()), nodeList.get(sc.nextInt()));
         }
 

--- a/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/graph/GraphParser.java
@@ -43,7 +43,7 @@ public final class GraphParser extends Parser<GraphMap> {
         NodeParser nodeParser = new NodeParser();
         List<Node> nodes = new ArrayList<>();
 
-        while (sc.hasNext() && !cancelled) {
+        while (sc.hasNext() && !isCancelled()) {
             Node n = nodeParser.getNode(sc);
             nodes.add(n);
             graphMap.addVertex(n);
@@ -65,7 +65,7 @@ public final class GraphParser extends Parser<GraphMap> {
 
         Scanner sc = new Scanner(edgeReader);
 
-        while (sc.hasNext() && !cancelled) {
+        while (sc.hasNext() && !isCancelled()) {
             graphMap.addEdge(nodeList.get(sc.nextInt()), nodeList.get(sc.nextInt()));
         }
 

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/NewickParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/NewickParser.java
@@ -51,9 +51,6 @@ public final class NewickParser extends Parser<Newick> {
      * @param newick the tree to add the nodes and edges to
      */
     public void getOffspring(final TreeNode node, final AbstractNode parent, final Newick newick) {
-        if (cancelled) {
-            return;
-        }
         for (int i = 0; i < node.numberLeaves; i += 1) {
             TreeNode child = node.getChild(i);
             if (child != null) {

--- a/geex-models/src/main/java/nl/tudelft/context/model/newick/NewickParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/newick/NewickParser.java
@@ -51,6 +51,9 @@ public final class NewickParser extends Parser<Newick> {
      * @param newick the tree to add the nodes and edges to
      */
     public void getOffspring(final TreeNode node, final AbstractNode parent, final Newick newick) {
+        if (cancelled) {
+            return;
+        }
         for (int i = 0; i < node.numberLeaves; i += 1) {
             TreeNode child = node.getChild(i);
             if (child != null) {

--- a/geex-models/src/main/java/nl/tudelft/context/model/resistance/ResistanceParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/resistance/ResistanceParser.java
@@ -27,7 +27,7 @@ public class ResistanceParser extends Parser<ResistanceMap> {
         ResistanceMap resistanceMap = new ResistanceMap();
         String line;
         int index = 0;
-        while (sc.hasNextLine()) {
+        while (sc.hasNextLine() && !cancelled) {
             line = sc.nextLine();
             while (line.matches("^##.*$")) {
                 line = sc.nextLine();

--- a/geex-models/src/main/java/nl/tudelft/context/model/resistance/ResistanceParser.java
+++ b/geex-models/src/main/java/nl/tudelft/context/model/resistance/ResistanceParser.java
@@ -27,7 +27,7 @@ public class ResistanceParser extends Parser<ResistanceMap> {
         ResistanceMap resistanceMap = new ResistanceMap();
         String line;
         int index = 0;
-        while (sc.hasNextLine() && !cancelled) {
+        while (sc.hasNextLine() && !isCancelled()) {
             line = sc.nextLine();
             while (line.matches("^##.*$")) {
                 line = sc.nextLine();

--- a/geex-services/src/main/java/nl/tudelft/context/service/LoadService.java
+++ b/geex-services/src/main/java/nl/tudelft/context/service/LoadService.java
@@ -6,10 +6,10 @@ import javafx.concurrent.Task;
 import java.io.File;
 
 /**
+ * @param <T> The type of class to Load.
  * @author Gerben Oolbekkink
  * @version 1.0
  * @since 24-5-2015
- * @param <T> The type of class to Load.
  */
 public class LoadService<T> extends Service<T> {
     /**
@@ -23,8 +23,9 @@ public class LoadService<T> extends Service<T> {
 
     /**
      * Create a new Loader service.
+     *
      * @param parserClass Class used for parsing the files.
-     * @param files Files to load.
+     * @param files       Files to load.
      */
     public LoadService(final Class<? extends Loadable<T>> parserClass, final File... files) {
         this.parserClass = parserClass;
@@ -36,11 +37,18 @@ public class LoadService<T> extends Service<T> {
     @Override
     protected Task<T> createTask() {
         return new Task<T>() {
+            private Loadable<T> parser;
+
             @Override
             protected T call() throws Exception {
-                Loadable<T> parser = parserClass.newInstance();
+                parser = parserClass.newInstance();
                 parser.setFiles(files);
                 return parser.load();
+            }
+
+            @Override
+            protected void cancelled() {
+                parser.cancelled();
             }
         };
     }

--- a/geex-services/src/main/java/nl/tudelft/context/service/Loadable.java
+++ b/geex-services/src/main/java/nl/tudelft/context/service/Loadable.java
@@ -31,4 +31,6 @@ public interface Loadable<T> {
      * @throws UnsupportedEncodingException Unsupported encoding
      */
     Loadable<T> setFiles(final File... files) throws FileNotFoundException, UnsupportedEncodingException;
+
+    void cancelled();
 }

--- a/geex-services/src/main/java/nl/tudelft/context/service/Loadable.java
+++ b/geex-services/src/main/java/nl/tudelft/context/service/Loadable.java
@@ -32,5 +32,8 @@ public interface Loadable<T> {
      */
     Loadable<T> setFiles(final File... files) throws FileNotFoundException, UnsupportedEncodingException;
 
+    /**
+     * Set the state of this Loadable to cancelled.
+     */
     void cancelled();
 }

--- a/geex-workspace/src/main/java/nl/tudelft/context/workspace/Workspace.java
+++ b/geex-workspace/src/main/java/nl/tudelft/context/workspace/Workspace.java
@@ -182,4 +182,15 @@ public class Workspace {
         return loadResistanceService.valueProperty();
     }
 
+    /**
+     * Close this workspace.
+     *
+     * Cancel all the running services, in order to clean up all the threads.
+     */
+    public void close() {
+        loadAnnotationService.cancel();
+        loadGraphService.cancel();
+        loadNewickService.cancel();
+        loadResistanceService.cancel();
+    }
 }


### PR DESCRIPTION
Services are now cancelled when a new workspace is loaded.
## Important

When creating a new parser, make sure to check `isCancelled()` often. It is impossible in Java to kill threads, so the only way to prematurely exit threads is by making them finish.
