### PR TITLE
Actually test An Infiniteparser

### DIFF
--- a/geex-services/src/test/java/nl/tudelft/context/service/LoadGraphServiceTest.java
+++ b/geex-services/src/test/java/nl/tudelft/context/service/LoadGraphServiceTest.java
@@ -97,7 +97,7 @@ public class LoadGraphServiceTest {
 
     @Test
     public void testInfiniteParser() throws Exception {
-        final LoadService<Boolean> loadGraphService = new LoadService<>(MyParser.class, nodeFile, edgeFile);
+        final LoadService<Boolean> loadGraphService = new LoadService<>(InfiniteParser.class, nodeFile, edgeFile);
 
         CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
 


### PR DESCRIPTION
Use InfiniteParser in LoadGraphService test. This test can always be cancelled, contrary to MyParser.

This caused [Travis build #1148](https://travis-ci.org/Vennik/contextproject/builds/66829442) to fail.
